### PR TITLE
Add autonomous navigation with localization and path planning

### DIFF
--- a/operate.py
+++ b/operate.py
@@ -1,5 +1,8 @@
-import cv2 
+import cv2
 import time
+import json
+import math
+import heapq
 import shutil
 import argparse
 import os, sys
@@ -18,6 +21,115 @@ from slam.aruco_sensor import ArucoSensor
 sys.path.insert(0,"{}/cv/".format(os.getcwd()))
 from cv.detector import ObjectDetector
 
+
+class GridAStar:
+    """Grid-based A* planner that keeps obstacles inflated by a safety margin."""
+
+    def __init__(self, arena_size=2.5, resolution=0.05, obstacles=None):
+        self.arena_size = float(arena_size)
+        self.resolution = float(resolution)
+        self.half_extent = self.arena_size / 2.0
+        self.min_coord = -self.half_extent
+        self.max_coord = self.half_extent
+        self.width = int(math.ceil(self.arena_size / self.resolution)) + 1
+        self.height = self.width
+        self.obstacle_grid = [[False for _ in range(self.height)] for _ in range(self.width)]
+        self.obstacles = []
+        if obstacles:
+            for ox, oy, radius in obstacles:
+                self.add_obstacle(ox, oy, radius)
+
+    def in_bounds(self, idx):
+        x, y = idx
+        return 0 <= x < self.width and 0 <= y < self.height
+
+    def is_obstacle(self, idx):
+        x, y = idx
+        return self.obstacle_grid[x][y]
+
+    def world_to_index(self, pt):
+        x, y = pt
+        if not self.world_in_bounds(pt):
+            return None
+        ix = int(math.floor((x - self.min_coord) / self.resolution))
+        iy = int(math.floor((y - self.min_coord) / self.resolution))
+        if 0 <= ix < self.width and 0 <= iy < self.height:
+            return (ix, iy)
+        return None
+
+    def index_to_world(self, idx):
+        x, y = idx
+        wx = self.min_coord + (x + 0.5) * self.resolution
+        wy = self.min_coord + (y + 0.5) * self.resolution
+        return (wx, wy)
+
+    def world_in_bounds(self, pt):
+        x, y = pt
+        return (self.min_coord <= x <= self.max_coord and
+                self.min_coord <= y <= self.max_coord)
+
+    def add_obstacle(self, x, y, radius):
+        self.obstacles.append((x, y, radius))
+        if not self.world_in_bounds((x, y)):
+            return
+        min_x = max(self.min_coord, x - radius)
+        max_x = min(self.max_coord, x + radius)
+        min_y = max(self.min_coord, y - radius)
+        max_y = min(self.max_coord, y + radius)
+        ix_min = max(0, int(math.floor((min_x - self.min_coord) / self.resolution)))
+        ix_max = min(self.width - 1, int(math.ceil((max_x - self.min_coord) / self.resolution)))
+        iy_min = max(0, int(math.floor((min_y - self.min_coord) / self.resolution)))
+        iy_max = min(self.height - 1, int(math.ceil((max_y - self.min_coord) / self.resolution)))
+        radius_sq = radius * radius
+        for ix in range(ix_min, ix_max + 1):
+            for iy in range(iy_min, iy_max + 1):
+                wx, wy = self.index_to_world((ix, iy))
+                if (wx - x) ** 2 + (wy - y) ** 2 <= radius_sq:
+                    self.obstacle_grid[ix][iy] = True
+
+    def plan(self, start, goal):
+        start_idx = self.world_to_index(start)
+        goal_idx = self.world_to_index(goal)
+        if start_idx is None or goal_idx is None:
+            return []
+        if self.is_obstacle(goal_idx):
+            return []
+        # allow start index even if marked as obstacle (robot may start inside inflated radius)
+        open_set = []
+        heapq.heappush(open_set, (0.0, start_idx))
+        came_from = {}
+        g_cost = {start_idx: 0.0}
+        neighbor_moves = [
+            ((1, 0), 1.0), ((-1, 0), 1.0), ((0, 1), 1.0), ((0, -1), 1.0),
+            ((1, 1), math.sqrt(2)), ((1, -1), math.sqrt(2)),
+            ((-1, 1), math.sqrt(2)), ((-1, -1), math.sqrt(2))
+        ]
+
+        def heuristic(a, b):
+            return math.hypot(a[0] - b[0], a[1] - b[1])
+
+        while open_set:
+            _, current = heapq.heappop(open_set)
+            if current == goal_idx:
+                path = [current]
+                while current in came_from:
+                    current = came_from[current]
+                    path.append(current)
+                path.reverse()
+                return [self.index_to_world(idx) for idx in path]
+            for move, move_cost in neighbor_moves:
+                neighbor = (current[0] + move[0], current[1] + move[1])
+                if not self.in_bounds(neighbor):
+                    continue
+                if neighbor != start_idx and self.is_obstacle(neighbor):
+                    continue
+                tentative_g = g_cost[current] + move_cost
+                if tentative_g < g_cost.get(neighbor, float('inf')):
+                    came_from[neighbor] = current
+                    g_cost[neighbor] = tentative_g
+                    f_cost = tentative_g + heuristic(neighbor, goal_idx)
+                    heapq.heappush(open_set, (f_cost, neighbor))
+        return []
 
 class Operate:
     def __init__(self, args):
@@ -58,27 +170,87 @@ class Operate:
             # Delete the folder and create an empty one, i.e. every operate.py is run, this folder will be empty.
             shutil.rmtree(self.raw_img_dir)
             os.makedirs(self.raw_img_dir)
-        
 
-        # Other auxiliary objects/variables      
+        # Autonomous navigation configuration
+        self.true_map_path = args.true_map
+        self.true_map = self.load_true_map(self.true_map_path)
+        if self.true_map.get('markers'):
+            try:
+                self.ekf.load_map(self.true_map_path)
+            except FileNotFoundError:
+                pass
+        self.obstacles = self.true_map.get('obstacles', [])
+        self.planner = GridAStar(arena_size=2.5, resolution=0.05, obstacles=self.obstacles)
+        self.autonomous_goal = None
+        self.path_world = []
+        self.remaining_path = []
+        self.following_path = False
+        self.slam_res = (520, 520)
+        self.map_surface_rect = None
+        self.max_linear_speed = 0.25
+        self.max_angular_speed = 1.2
+        self.linear_gain = 0.8
+        self.angular_gain = 2.0
+        self.waypoint_tolerance = 0.05
+
+
+        # Other auxiliary objects/variables
         self.quit = False
         self.pred_fname = ''
         self.request_recover_robot = False
         self.obj_detector_output = None
-        self.ekf_on = False
+        self.ekf_on = True
         self.double_reset_comfirm = 0
         self.image_id = 0
-        self.notification = 'Press ENTER to start SLAM'
+        self.notification = 'Performing localization scan...'
         self.count_down = 300 # 5 min timer
         self.start_time = time.time()
         self.control_clock = time.time()
         self.img = np.zeros([480,640,3], dtype=np.uint8)
         self.aruco_img = np.zeros([480,640,3], dtype=np.uint8)
-        self.obj_detector_pred = np.zeros([480,640], dtype=np.uint8)        
+        self.obj_detector_pred = np.zeros([480,640], dtype=np.uint8)
         self.bg = pygame.image.load('ui/gui_mask.jpg')
 
+        # Perform an initial localization spin to detect nearby markers
+        self.initial_localization_scan()
+        self.notification = 'Localization complete. Click the map to set a goal.'
+
+    def load_true_map(self, path):
+        true_map = {'markers': {}, 'fruits': {}, 'obstacles': []}
+        if not path:
+            return true_map
+        try:
+            with open(path, 'r') as f:
+                data = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            return true_map
+        for name, entry in data.items():
+            x = float(entry.get('x', 0.0))
+            y = float(entry.get('y', 0.0))
+            if name.startswith('aruco'):
+                true_map['markers'][name] = (x, y)
+            else:
+                true_map['fruits'][name] = (x, y)
+            true_map['obstacles'].append((x, y, 0.2))
+        return true_map
+
+    def initial_localization_scan(self, duration=6.0, spin_speed=0.15):
+        start_time = time.time()
+        previous_command = list(self.command['wheel_speed'])
+        try:
+            self.command['wheel_speed'] = [-spin_speed, spin_speed]
+            while time.time() - start_time < duration and not self.quit:
+                drive_measurement = self.control()
+                time.sleep(0.15)
+                self.take_pic()
+                self.perform_slam(drive_measurement)
+        finally:
+            self.command['wheel_speed'] = [0.0, 0.0]
+            self.control()
+            self.command['wheel_speed'] = previous_command
+
     # wheel control
-    def control(self):       
+    def control(self):
         left_speed, right_speed = self.botconnect.set_velocity(self.command['wheel_speed'])
         dt = time.time() - self.control_clock
         drive_measurement = DriveMeasurement(left_speed, right_speed, dt)
@@ -181,7 +353,113 @@ class Operate:
             self.command['run_obj_detector'] = False
 
 
-    # paint the GUI            
+    def screen_to_world(self, screen_pos):
+        if not self.map_surface_rect:
+            return None
+        local_x = screen_pos[0] - self.map_surface_rect.left
+        local_y = screen_pos[1] - self.map_surface_rect.top
+        if local_x < 0 or local_y < 0 or local_x >= self.map_surface_rect.width or local_y >= self.map_surface_rect.height:
+            return None
+        w, h = self.slam_res
+        x_canvas = w - 1 - local_y + 0.5
+        y_canvas = h - 1 - local_x + 0.5
+        m2pixel = 100.0
+        rel_x = (w / 2.0 - x_canvas) / m2pixel
+        rel_y = (y_canvas - h / 2.0) / m2pixel
+        robot_state = self.ekf.robot.state
+        world_x = robot_state[0, 0] + rel_x
+        world_y = robot_state[1, 0] + rel_y
+        world_point = (world_x, world_y)
+        if not self.planner.world_in_bounds(world_point):
+            return None
+        return world_point
+
+    def plan_path_to(self, goal_world):
+        start = (self.ekf.robot.state[0, 0], self.ekf.robot.state[1, 0])
+        path = self.planner.plan(start, goal_world)
+        if len(path) < 2:
+            self.following_path = False
+            self.command['wheel_speed'] = [0.0, 0.0]
+            self.remaining_path = []
+            if len(path) == 1:
+                self.notification = 'Already at the selected location.'
+                self.autonomous_goal = goal_world
+                self.path_world = path
+            else:
+                self.notification = 'Unable to find a collision-free path.'
+                self.autonomous_goal = None
+                self.path_world = []
+            return
+        self.autonomous_goal = goal_world
+        self.path_world = path
+        self.remaining_path = path[1:]
+        self.following_path = True
+        self.notification = 'Autonomous navigation engaged.'
+
+    def update_autonomy(self):
+        if not self.following_path:
+            return
+        if not self.remaining_path:
+            self.command['wheel_speed'] = [0.0, 0.0]
+            self.following_path = False
+            self.notification = 'Destination reached.'
+            return
+        self._drive_towards_next_waypoint()
+
+    def _drive_towards_next_waypoint(self):
+        pose = self.ekf.robot.state
+        robot_xy = np.array([pose[0, 0], pose[1, 0]])
+        target_xy = np.array(self.remaining_path[0])
+        distance = np.linalg.norm(target_xy - robot_xy)
+        if distance < self.waypoint_tolerance:
+            self.remaining_path.pop(0)
+            if not self.remaining_path:
+                self.command['wheel_speed'] = [0.0, 0.0]
+                self.following_path = False
+                self.notification = 'Destination reached.'
+            return
+        heading = math.atan2(target_xy[1] - robot_xy[1], target_xy[0] - robot_xy[0])
+        heading_error = self._normalize_angle(heading - pose[2, 0])
+        linear_velocity = max(-self.max_linear_speed,
+                              min(self.max_linear_speed, self.linear_gain * distance))
+        angular_velocity = max(-self.max_angular_speed,
+                               min(self.max_angular_speed, self.angular_gain * heading_error))
+        if abs(heading_error) > math.pi / 4:
+            linear_velocity *= 0.4
+        self._set_wheel_speeds_from_twist(linear_velocity, angular_velocity)
+
+    def _set_wheel_speeds_from_twist(self, linear_velocity, angular_velocity):
+        baseline = self.ekf.robot.baseline
+        scale = self.ekf.robot.scale if self.ekf.robot.scale != 0 else 1.0
+        left_m = linear_velocity - angular_velocity * baseline / 2.0
+        right_m = linear_velocity + angular_velocity * baseline / 2.0
+        left_cmd = max(-1.0, min(1.0, left_m / scale))
+        right_cmd = max(-1.0, min(1.0, right_m / scale))
+        self.command['wheel_speed'] = [left_cmd, right_cmd]
+
+    @staticmethod
+    def _normalize_angle(angle):
+        return (angle + math.pi) % (2 * math.pi) - math.pi
+
+    def cancel_autonomy(self, reason=None):
+        self.following_path = False
+        self.remaining_path = []
+        self.path_world = []
+        self.autonomous_goal = None
+        self.command['wheel_speed'] = [0.0, 0.0]
+        if reason:
+            self.notification = reason
+
+    def set_goal_from_click(self, position):
+        self.cancel_autonomy()
+        goal_world = self.screen_to_world(position)
+        if goal_world is None:
+            self.notification = 'Selected point is outside the valid map area.'
+            return
+        self.plan_path_to(goal_world)
+
+
+    # paint the GUI
     def draw(self, canvas):
         width, height = 900, 660
         canvas = pygame.display.set_mode((width, height))
@@ -190,8 +468,17 @@ class Operate:
         v_pad, h_pad = 40, 20
 
         # paint SLAM outputs
-        ekf_view = self.ekf.draw_slam_state(res=(520, 480+v_pad), not_pause = self.ekf_on)
-        canvas.blit(ekf_view, (2*h_pad+320, v_pad))
+        res = self.slam_res
+        ekf_view = self.ekf.draw_slam_state(
+            res=res,
+            not_pause=self.ekf_on,
+            path=self.path_world if self.path_world else None,
+            goal=self.autonomous_goal
+        )
+        map_position = (2*h_pad+320, v_pad)
+        canvas.blit(ekf_view, map_position)
+        self.map_surface_rect = pygame.Rect(map_position[0], map_position[1],
+                                            ekf_view.get_width(), ekf_view.get_height())
         robot_view = cv2.resize(self.aruco_img, (320, 240))
         self.draw_pygame_window(canvas, robot_view, position=(h_pad, v_pad))
 
@@ -236,22 +523,25 @@ class Operate:
     def handle_event(self, event):
         # drive forward
         if event.type == pygame.KEYDOWN and event.key == pygame.K_UP:
+            self.cancel_autonomy('Manual override enabled.')
             self.command['wheel_speed'] = [0.3, 0.3]
-             # TODO
         # drive backward
         elif event.type == pygame.KEYDOWN and event.key == pygame.K_DOWN:
-            self.command['wheel_speed'] = [-0.3,-0.3]
-             # TODO
+            self.cancel_autonomy('Manual override enabled.')
+            self.command['wheel_speed'] = [-0.3, -0.3]
         # turn left
         elif event.type == pygame.KEYDOWN and event.key == pygame.K_LEFT:
-            self.command['wheel_speed'] = [-0.3,0.3]
-             # TODO
-        # drive right
+            self.cancel_autonomy('Manual override enabled.')
+            self.command['wheel_speed'] = [-0.3, 0.3]
+        # turn right
         elif event.type == pygame.KEYDOWN and event.key == pygame.K_RIGHT:
-            self.command['wheel_speed'] = [0.3,-0.3]
-             # TODO
-        # stop
-        elif event.type == pygame.KEYUP or (event.type == pygame.KEYDOWN and event.key == pygame.K_SPACE):
+            self.cancel_autonomy('Manual override enabled.')
+            self.command['wheel_speed'] = [0.3, -0.3]
+        # stop via keyboard
+        elif event.type == pygame.KEYDOWN and event.key == pygame.K_SPACE:
+            self.cancel_autonomy('Manual override enabled.')
+            self.command['wheel_speed'] = [0, 0]
+        elif event.type == pygame.KEYUP:
             self.command['wheel_speed'] = [0, 0]
         # run SLAM
         elif event.type == pygame.KEYDOWN and event.key == pygame.K_RETURN:
@@ -307,6 +597,8 @@ class Operate:
             self.notification = ('Mode: LOCALIZATION-ONLY (map frozen)'
                                 if self.ekf.localization_only else
                                 'Mode: SLAM (map can update)')
+        elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            self.set_goal_from_click(event.pos)
         # quit
         elif event.type == pygame.QUIT:
             self.quit = True
@@ -326,6 +618,7 @@ if __name__ == "__main__":
     parser.add_argument("--ip", metavar='', type=str, default='localhost') # you can hardcode ip here, but it may change from time to time.
     parser.add_argument("--calib_dir", type=str, default="calibration/param/")
     parser.add_argument("--ckpt", default='cv/model/model.best.pt')
+    parser.add_argument("--true_map", type=str, default='truemap.txt')
     args, _ = parser.parse_known_args()
     
     pygame.font.init() 
@@ -361,6 +654,7 @@ if __name__ == "__main__":
     operate = Operate(args)
     while start:
         operate.update_keyboard()
+        operate.update_autonomy()
         operate.take_pic()
         drive_measurement = operate.control()
         operate.perform_slam(drive_measurement)

--- a/slam/ekf.py
+++ b/slam/ekf.py
@@ -303,7 +303,7 @@ class EKF:
         y_im = int(y*m2pixel+h/2.0)
         return (x_im, y_im)
 
-    def draw_slam_state(self, res = (320, 500), not_pause=True):
+    def draw_slam_state(self, res = (320, 500), not_pause=True, path=None, goal=None):
         # Draw landmarks
         m2pixel = 100
         if not_pause:
@@ -311,7 +311,7 @@ class EKF:
         else:
             bg_rgb = np.array([120, 120, 120]).reshape(1, 1, 3)
         canvas = np.ones((res[1], res[0], 3))*bg_rgb.astype(np.uint8)
-        # in meters, 
+        # in meters,
         lms_xy = self.markers[:2, :]
         robot_xy = self.robot.state[:2, 0].reshape((2, 1))
         lms_xy = lms_xy - robot_xy
@@ -319,7 +319,7 @@ class EKF:
         robot_theta = self.robot.state[2,0]
         # plot robot
         start_point_uv = self.to_im_coor((0, 0), res, m2pixel)
-        
+
         p_robot = self.P[0:2,0:2]
         axes_len,angle = self.make_ellipse(p_robot)
         canvas = cv2.ellipse(canvas, start_point_uv, (int(axes_len[0]*m2pixel), int(axes_len[1]*m2pixel)), angle, 0, 360, (0, 30, 56), 1)
@@ -332,6 +332,24 @@ class EKF:
                 Plmi = self.P[3+2*i:3+2*(i+1),3+2*i:3+2*(i+1)]
                 axes_len, angle = self.make_ellipse(Plmi)
                 canvas = cv2.ellipse(canvas, coor_, (int(axes_len[0]*m2pixel), int(axes_len[1]*m2pixel)), angle, 0, 360, (244, 69, 96), 1)
+
+        if path:
+            pts = []
+            for world_xy in path:
+                rel = (world_xy[0] - self.robot.state[0, 0],
+                       world_xy[1] - self.robot.state[1, 0])
+                pts.append(self.to_im_coor(rel, res, m2pixel))
+            if len(pts) == 1:
+                canvas = cv2.circle(canvas, pts[0], 5, (60, 60, 200), -1)
+            elif len(pts) > 1:
+                pts_arr = np.array(pts, dtype=np.int32).reshape(-1, 1, 2)
+                canvas = cv2.polylines(canvas, [pts_arr], False, (60, 60, 200), 2)
+
+        if goal is not None:
+            rel_goal = (goal[0] - self.robot.state[0, 0],
+                        goal[1] - self.robot.state[1, 0])
+            goal_uv = self.to_im_coor(rel_goal, res, m2pixel)
+            canvas = cv2.circle(canvas, goal_uv, 6, (40, 180, 40), -1)
 
         surface = pygame.surfarray.make_surface(np.rot90(canvas))
         surface = pygame.transform.flip(surface, True, False)


### PR DESCRIPTION
## Summary
- add a grid-based A* planner with inflated obstacles from the true map to drive autonomously toward clicked targets
- run an initial localization spin that uses detected markers to recover the robot pose and show it on the SLAM view
- render planned paths/goals on the SLAM map and convert mouse clicks into autonomous navigation commands

## Testing
- python3 -m compileall operate.py slam/ekf.py

------
https://chatgpt.com/codex/tasks/task_e_68d687c16d6c8328876b75ad087ea1fa