### PR TITLE
Refine path generation and tracking

### DIFF
--- a/operate.py
+++ b/operate.py
@@ -8,7 +8,6 @@ import pygame
 from botconnect import BotConnect
 import json
 import heapq
-from collections import deque
 
 # ---- SLAM components (M2) ----
 sys.path.insert(0, "{}/slam".format(os.getcwd()))
@@ -23,189 +22,194 @@ from cv.detector import ObjectDetector
 
 
 # ===============================
-#        A* Pathfinder (from your working code)
+#        Grid-based Pathfinder
 # ===============================
+
 class AStarPathfinder:
-    """Standard A* pathfinding on 8-connected grid"""
-    def __init__(self, grid):
-        self.grid = grid
-        self.rows, self.cols = grid.shape
-        
-    def heuristic(self, a, b):
-        dx = abs(a[0] - b[0])
-        dy = abs(a[1] - b[1])
-        return max(dx, dy) + (np.sqrt(2) - 1) * min(dx, dy)
+    """Robust 8-connected A* planner with deterministic smoothing."""
+
+    # 8-connected motion model: (dr, dc, cost)
+    _NEIGHBOR_OFFSETS = [
+        (-1, 0, 1.0), (1, 0, 1.0), (0, -1, 1.0), (0, 1, 1.0),
+        (-1, -1, np.sqrt(2)), (-1, 1, np.sqrt(2)), (1, -1, np.sqrt(2)), (1, 1, np.sqrt(2)),
+    ]
+
+    def __init__(self, grid: np.ndarray):
+        self.set_grid(grid)
+
+    def set_grid(self, grid: np.ndarray):
+        self.grid = np.array(grid, dtype=np.uint8)
+        self.rows, self.cols = self.grid.shape
+
+    @staticmethod
+    def _heuristic(a, b):
+        return np.hypot(a[0] - b[0], a[1] - b[1])
+
+    def _in_bounds(self, r, c):
+        return 0 <= r < self.rows and 0 <= c < self.cols
+
+    def _is_free(self, r, c):
+        return self.grid[r, c] == 0
 
     def get_neighbors(self, node):
         r, c = node
-        nbrs = []
-        for dr, dc in [(-1,-1), (-1,0), (-1,1), (0,-1), (0,1), (1,-1), (1,0), (1,1)]:
-            rr, cc = r + dr, c + dc
-            if 0 <= rr < self.rows and 0 <= cc < self.cols and self.grid[rr, cc] == 0:
-                nbrs.append((rr, cc))
-        return nbrs
+        for dr, dc, cost in self._NEIGHBOR_OFFSETS:
+            nr, nc = r + dr, c + dc
+            if self._in_bounds(nr, nc) and self._is_free(nr, nc):
+                yield (nr, nc), cost
 
-    def has_line_of_sight(self, a, b):
-        r0, c0 = a
-        r1, c1 = b
+    def has_line_of_sight(self, start, goal):
+        """Bresenham line check for collision free segment."""
+        r0, c0 = start
+        r1, c1 = goal
         dr = abs(r1 - r0)
         dc = abs(c1 - c0)
         sr = 1 if r1 >= r0 else -1
         sc = 1 if c1 >= c0 else -1
+        err = dr - dc
 
         r, c = r0, c0
-        if dc > dr:
-            err = dc // 2
-            while c != c1:
-                if self.grid[r, c] == 1:
-                    return False
-                c += sc
-                err -= dr
-                if err < 0:
-                    r += sr
-                    err += dc
-        else:
-            err = dr // 2
-            while r != r1:
-                if self.grid[r, c] == 1:
-                    return False
-                r += sr
+        while True:
+            if not self._is_free(r, c):
+                return False
+            if (r, c) == (r1, c1):
+                return True
+            e2 = 2 * err
+            if e2 > -dc:
                 err -= dc
-                if err < 0:
-                    c += sc
-                    err += dr
-        return self.grid[r1, c1] == 0
+                r += sr
+            if e2 < dr:
+                err += dr
+                c += sc
 
     def find_path(self, start, goal):
-        if self.grid[start[0], start[1]] != 0 or self.grid[goal[0], goal[1]] != 0:
+        if not (self._in_bounds(*start) and self._in_bounds(*goal)):
+            return []
+        if not (self._is_free(*start) and self._is_free(*goal)):
             return []
 
-        open_set = []
-        heapq.heappush(open_set, (0.0, start))
+        open_heap = [(0.0, start)]
         came_from = {}
         g_score = {start: 0.0}
-        f_score = {start: self.heuristic(start, goal)}
-        in_open = {start}
+        visited = set()
 
-        while open_set:
-            _, current = heapq.heappop(open_set)
-            in_open.discard(current)
+        while open_heap:
+            _, current = heapq.heappop(open_heap)
+            if current in visited:
+                continue
+            visited.add(current)
 
             if current == goal:
-                path = [current]
-                while current in came_from:
-                    current = came_from[current]
-                    path.append(current)
-                path.reverse()
-                return path
+                return self._reconstruct_path(came_from, current)
 
-            for neighbor in self.get_neighbors(current):
-                tentative_g = g_score[current] + self.heuristic(current, neighbor)
-
-                if neighbor not in g_score or tentative_g < g_score[neighbor]:
+            for neighbor, cost in self.get_neighbors(current):
+                tentative_g = g_score[current] + cost
+                if tentative_g < g_score.get(neighbor, float('inf')):
                     came_from[neighbor] = current
                     g_score[neighbor] = tentative_g
-                    f = tentative_g + self.heuristic(neighbor, goal)
-                    f_score[neighbor] = f
-                    if neighbor not in in_open:
-                        heapq.heappush(open_set, (f, neighbor))
-                        in_open.add(neighbor)
+                    f_score = tentative_g + self._heuristic(neighbor, goal)
+                    heapq.heappush(open_heap, (f_score, neighbor))
 
         return []
 
+    def _reconstruct_path(self, came_from, current):
+        path = [current]
+        while current in came_from:
+            current = came_from[current]
+            path.append(current)
+        path.reverse()
+        return path
 
-# ===============================
-#    Path Smoothing (from your working code)
-# ===============================
-def advanced_smooth_path(path_world, world_to_grid_fn, has_los_fn, iterations=3):
+    def simplify(self, path):
+        """Remove intermediate waypoints that are redundant."""
+        if len(path) < 3:
+            return path
+
+        simplified = [path[0]]
+        anchor_idx = 0
+
+        for idx in range(2, len(path)):
+            if not self.has_line_of_sight(path[anchor_idx], path[idx]):
+                simplified.append(path[idx - 1])
+                anchor_idx = idx - 1
+
+        simplified.append(path[-1])
+        return self._deduplicate(simplified)
+
+    @staticmethod
+    def _deduplicate(path):
+        deduped = [path[0]]
+        for point in path[1:]:
+            if point != deduped[-1]:
+                deduped.append(point)
+        return deduped
+
+
+def smooth_world_path(path_world, world_to_grid_fn, has_los_fn):
+    """Deterministic shortcutting that respects map obstacles."""
     if len(path_world) < 3:
         return path_world
-    smoothed = shortcut_path_world(path_world, world_to_grid_fn, has_los_fn, trials=200)
-    smoothed = remove_redundant_points(smoothed, world_to_grid_fn, has_los_fn)
-    smoothed = chaikin_smooth(smoothed, iterations=iterations, alpha=0.25)
-    smoothed = optimize_turning_points(smoothed, world_to_grid_fn, has_los_fn)
-    return smoothed
 
-def remove_redundant_points(path_world, world_to_grid_fn, has_los_fn, angle_threshold=0.1):
-    if len(path_world) < 3:
-        return path_world
-    result = [path_world[0]]
-    for i in range(1, len(path_world) - 1):
-        p0 = np.array(path_world[i - 1])
-        p1 = np.array(path_world[i])
-        p2 = np.array(path_world[i + 1])
-        v1 = p1 - p0
-        v2 = p2 - p1
-        n1 = np.linalg.norm(v1)
-        n2 = np.linalg.norm(v2)
-        if n1 > 1e-6 and n2 > 1e-6:
-            v1 = v1 / n1
-            v2 = v2 / n2
-            dot_product = np.clip(np.dot(v1, v2), -1.0, 1.0)
-            angle = np.arccos(dot_product)
-            if angle > angle_threshold:
-                result.append(path_world[i])
-        else:
-            result.append(path_world[i])
-    result.append(path_world[-1])
-    return result
+    simplified = [path_world[0]]
+    anchor = path_world[0]
+    anchor_grid = world_to_grid_fn(anchor)
 
-def optimize_turning_points(path_world, world_to_grid_fn, has_los_fn):
-    if len(path_world) < 3:
-        return path_world
-    result = [path_world[0]]
-    i = 1
-    while i < len(path_world):
-        best_j = i
-        max_j = min(i + 5, len(path_world) - 1)
-        for j in range(max_j, i, -1):
-            if j >= len(path_world):
-                continue
-            grid_i = world_to_grid_fn(result[-1])
-            grid_j = world_to_grid_fn(path_world[j])
-            if has_los_fn(grid_i, grid_j):
-                best_j = j
-                break
-        if best_j > i:
-            result.append(path_world[best_j])
-            i = best_j + 1
-        else:
-            result.append(path_world[i])
-            i += 1
-    if result[-1] != path_world[-1]:
-        result.append(path_world[-1])
-    return result
+    for idx in range(2, len(path_world)):
+        candidate = path_world[idx]
+        candidate_grid = world_to_grid_fn(candidate)
+        if not has_los_fn(anchor_grid, candidate_grid):
+            prev = path_world[idx - 1]
+            simplified.append(prev)
+            anchor = prev
+            anchor_grid = world_to_grid_fn(anchor)
 
-def shortcut_path_world(path_world, world_to_grid_fn, has_los_fn, trials=200):
-    if len(path_world) < 3:
-        return path_world
-    pts = path_world[:]
-    for _ in range(trials):
-        if len(pts) < 3:
-            break
-        i = np.random.randint(0, len(pts) - 2)
-        j = np.random.randint(i + 2, len(pts))
-        a_grid = world_to_grid_fn(pts[i])
-        b_grid = world_to_grid_fn(pts[j])
-        if has_los_fn(a_grid, b_grid):
-            pts = pts[:i+1] + pts[j:]
-    return pts
+    simplified.append(path_world[-1])
 
-def chaikin_smooth(path_world, iterations=1, alpha=0.25):
-    if len(path_world) < 3 or iterations <= 0:
+    # Remove any duplicates that may have formed
+    cleaned = [simplified[0]]
+    for pt in simplified[1:]:
+        if pt != cleaned[-1]:
+            cleaned.append(pt)
+
+    return cleaned
+
+
+def densify_path(path_world, spacing):
+    """Insert intermediate waypoints so consecutive points remain close."""
+    if len(path_world) < 2:
         return path_world
-    out = path_world[:]
-    for _ in range(iterations):
-        newp = [out[0]]
-        for k in range(len(out) - 1):
-            p = np.array(out[k], dtype=float)
-            q = np.array(out[k+1], dtype=float)
-            Q = (1 - alpha) * p + alpha * q
-            R = alpha * p + (1 - alpha) * q
-            newp.extend([tuple(Q), tuple(R)])
-        newp.append(out[-1])
-        out = newp
-    return out
+
+    spacing = max(1e-3, float(spacing))
+    dense_path = [path_world[0]]
+
+    for idx in range(1, len(path_world)):
+        start = np.array(dense_path[-1], dtype=float)
+        end = np.array(path_world[idx], dtype=float)
+        segment = end - start
+        seg_len = float(np.linalg.norm(segment))
+
+        if seg_len < spacing:
+            if np.linalg.norm(end - np.array(dense_path[-1], dtype=float)) > 1e-6:
+                dense_path.append((float(end[0]), float(end[1])))
+            continue
+
+        direction = segment / seg_len
+        steps = int(np.floor(seg_len / spacing))
+
+        for step in range(1, steps + 1):
+            point = start + direction * min(seg_len, step * spacing)
+            dense_path.append((float(point[0]), float(point[1])))
+
+        if np.linalg.norm(np.array(dense_path[-1], dtype=float) - end) > 1e-6:
+            dense_path.append((float(end[0]), float(end[1])))
+
+    # Remove any duplicates that may have been appended at segment boundaries
+    cleaned = [dense_path[0]]
+    for point in dense_path[1:]:
+        if np.linalg.norm(np.array(point) - np.array(cleaned[-1])) > 1e-6:
+            cleaned.append(point)
+
+    return cleaned
 
 
 # ===============================
@@ -235,6 +239,7 @@ class Operate:
         self.true_map = self.load_true_map()
         self.grid_resolution = 0.05
         self.grid_size = int(2.5 / self.grid_resolution)
+        self.grid_origin = np.array([-1.25, -1.25], dtype=float)
         self.occupancy_grid = np.zeros((self.grid_size, self.grid_size))
         self.path_grid = []
         self.obstacle_radius_m = 0.22
@@ -288,13 +293,20 @@ class Operate:
         # Smoothing
         self.enable_smoothing = True
         self.smoothing_iterations = 2
+        self.path_densify_spacing = 0.06
 
         # Pure pursuit
         self.use_pure_pursuit = True
-        self.lookahead = 0.25
-        self.pp_max_linear = 0.25  # Reduced from 0.5 to 0.25 (half speed)
+        self.lookahead = 0.18
+        self.pp_max_linear = 0.23  # Reduced top speed for tighter tracking
         self.pp_max_angular = 0.8
+        self.pp_speed_gain = 1.2
         self.wp_reached_radius = 0.12
+        self.require_heading_alignment = False
+        self.heading_align_tolerance = 0.12
+        self.heading_align_gain = 2.0
+        self.heading_align_min_speed = 0.18
+        self.heading_align_max_speed = 0.6
 
         # UI state
         self.quit = False
@@ -325,28 +337,33 @@ class Operate:
     def create_occupancy_grid(self):
         self.occupancy_grid = np.zeros((self.grid_size, self.grid_size), dtype=np.uint8)
         obstacle_radius = self.obstacle_radius_m
-        grid_radius = max(1, int(obstacle_radius / self.grid_resolution))
+        grid_radius = max(1, int(np.ceil(obstacle_radius / self.grid_resolution)))
 
         for _, pos in self.true_map.items():
-            grid_x = int((pos['x'] + 1.25) / self.grid_resolution)
-            grid_y = int((pos['y'] + 1.25) / self.grid_resolution)
+            grid_y, grid_x = self.world_to_grid((pos['x'], pos['y']))
             for dx in range(-grid_radius, grid_radius + 1):
                 for dy in range(-grid_radius, grid_radius + 1):
-                    if dx*dx + dy*dy <= grid_radius*grid_radius:
+                    if dx * dx + dy * dy <= grid_radius * grid_radius:
                         nx, ny = grid_x + dx, grid_y + dy
                         if 0 <= nx < self.grid_size and 0 <= ny < self.grid_size:
                             self.occupancy_grid[ny, nx] = 1
 
+        if hasattr(self, 'pathfinder'):
+            self.pathfinder.set_grid(self.occupancy_grid)
+
     def world_to_grid(self, world_pos):
-        grid_x = int((world_pos[0] + 1.25) / self.grid_resolution)
-        grid_y = int((world_pos[1] + 1.25) / self.grid_resolution)
-        grid_x = max(0, min(grid_x, self.grid_size - 1))
-        grid_y = max(0, min(grid_y, self.grid_size - 1))
-        return (grid_y, grid_x)
+        wx, wy = float(world_pos[0]), float(world_pos[1])
+        gx = (wx - self.grid_origin[0]) / self.grid_resolution
+        gy = (wy - self.grid_origin[1]) / self.grid_resolution
+        col = int(np.clip(np.floor(gx), 0, self.grid_size - 1))
+        row = int(np.clip(np.floor(gy), 0, self.grid_size - 1))
+        return (row, col)
 
     def grid_to_world(self, grid_pos):
-        world_x = grid_pos[1] * self.grid_resolution - 1.25
-        world_y = grid_pos[0] * self.grid_resolution - 1.25
+        col = float(grid_pos[1])
+        row = float(grid_pos[0])
+        world_x = self.grid_origin[0] + (col + 0.5) * self.grid_resolution
+        world_y = self.grid_origin[1] + (row + 0.5) * self.grid_resolution
         return (world_x, world_y)
 
     def start_localization(self):
@@ -403,16 +420,37 @@ class Operate:
                 # Stop moving after re-localization completes
                 self.command['wheel_speed'] = [0, 0]
 
-                # Clear the path and target to stop autonomous movement
-                self.path = []
-                self.current_path_index = 0
-                self.target_point = None
-
                 self.in_relocalization = False
                 self.reset_rotation_variables()
                 self.last_relocalization_time = time.time()
-                self.autonomous_mode = False  # Stop autonomous mode
-                self.notification = f"Re-localized! Found {len(self.ekf.taglist)} markers. Stopped - click map to set new goal"
+
+                resume_msg = f"Re-localized! Found {len(self.ekf.taglist)} markers."
+
+                resumed = False
+
+                if self.saved_target is not None:
+                    if self.plan_path_to_target(self.saved_target):
+                        self.autonomous_mode = True
+                        self.target_point = self.saved_target
+                        self.notification = resume_msg + " Re-planned route to target."
+                        resumed = True
+                    else:
+                        self.notification = resume_msg + " Unable to re-plan path, trying saved route."
+
+                if not resumed and self._restore_saved_path():
+                    self.notification = resume_msg + " Resuming saved path."
+                    resumed = True
+
+                if not resumed:
+                    self.autonomous_mode = False
+                    self.path = []
+                    self.current_path_index = 0
+                    self.target_point = None
+                    self.notification = resume_msg + " Awaiting new goal."
+
+                self.saved_path = []
+                self.saved_path_index = 0
+                self.saved_target = None
 
     def perform_step_wise_rotation(self, now, is_initial=True):
         if self.step_start_time is None:
@@ -471,48 +509,121 @@ class Operate:
             self.notification = "No path found to target!"
             return False
 
+        self.path_grid = self.pathfinder.simplify(self.path_grid)
         self.path = [self.grid_to_world(gp) for gp in self.path_grid]
 
+        smoothing_msg = ""
         if self.enable_smoothing:
             original_length = len(self.path)
-            self.path = advanced_smooth_path(
+            smoothed_path = smooth_world_path(
                 self.path,
                 self.world_to_grid,
-                self.pathfinder.has_line_of_sight,
-                iterations=self.smoothing_iterations
+                self.pathfinder.has_line_of_sight
             )
-            self.notification = f"A* Path: {original_length} → {len(self.path)} waypoints (smoothed)"
-        else:
-            self.notification = f"A* Path: {len(self.path)} waypoints"
+            self.path = smoothed_path
+            smoothing_msg = f" smoothed {original_length}→{len(self.path)}."
+
+        densify_before = len(self.path)
+        self.path = densify_path(self.path, self.path_densify_spacing)
+        if len(self.path) != densify_before:
+            smoothing_msg += f" densified {densify_before}→{len(self.path)}."
+
+        if not smoothing_msg:
+            smoothing_msg = f" {len(self.path)} waypoints."
+
+        self.notification = "A* Path:" + smoothing_msg
 
         self.current_path_index = 0
+        self.require_heading_alignment = len(self.path) > 1
+        return True
+
+    def _restore_saved_path(self):
+        if not self.saved_path:
+            return False
+
+        self.path = self.saved_path.copy()
+
+        if not self.path:
+            return False
+
+        rx = float(self.ekf.robot.state[0, 0])
+        ry = float(self.ekf.robot.state[1, 0])
+
+        start_idx = min(max(self.saved_path_index, 0), len(self.path) - 1)
+        best_idx = start_idx
+        best_dist = float('inf')
+
+        for idx in range(start_idx, len(self.path)):
+            px, py = self.path[idx]
+            dist = np.hypot(px - rx, py - ry)
+            if dist < best_dist:
+                best_dist = dist
+                best_idx = idx
+            if best_dist <= self.wp_reached_radius * 0.5:
+                break
+
+        self.current_path_index = best_idx
+
+        # Skip waypoints that we are already on top of after re-localization
+        while (
+            self.current_path_index < len(self.path) - 1 and
+            np.hypot(self.path[self.current_path_index][0] - rx,
+                     self.path[self.current_path_index][1] - ry) <= self.wp_reached_radius * 0.5
+        ):
+            self.current_path_index += 1
+
+        if self.saved_target is not None:
+            self.target_point = self.saved_target
+        else:
+            self.target_point = self.path[-1]
+
+        self.autonomous_mode = True
+        self.require_heading_alignment = len(self.path) > 1
         return True
 
     def _find_lookahead_target(self, pose, path, lookahead):
         rx, ry = pose[0], pose[1]
-        start_idx = max(0, self.current_path_index)
+        lookahead_sq = max(lookahead * lookahead, 1e-6)
+        best_target = None
+        best_index = self.current_path_index
 
-        acc_dist = 0.0
+        start_idx = max(self.current_path_index - 1, 0)
+        robot_pos = np.array([rx, ry], dtype=float)
+
         for i in range(start_idx, len(path) - 1):
             p = np.array(path[i], dtype=float)
             q = np.array(path[i + 1], dtype=float)
-            seg = q - p
-            seg_len = np.linalg.norm(seg)
-            if seg_len < 1e-6:
+            d = q - p
+            seg_len_sq = float(np.dot(d, d))
+            if seg_len_sq < 1e-8:
                 continue
 
-            d_to_p = np.hypot(rx - p[0], ry - p[1])
-            d_to_q = np.hypot(rx - q[0], ry - q[1])
+            f = p - robot_pos
+            a = seg_len_sq
+            b = 2.0 * float(np.dot(f, d))
+            c = float(np.dot(f, f)) - lookahead_sq
+            discriminant = b * b - 4.0 * a * c
+            if discriminant < 0:
+                continue
 
-            if d_to_p <= lookahead <= d_to_q:
-                return float(q[0]), float(q[1]), i + 1
+            sqrt_disc = float(np.sqrt(discriminant))
+            t_candidates = [(-b - sqrt_disc) / (2.0 * a), (-b + sqrt_disc) / (2.0 * a)]
 
-            acc_dist += seg_len
-            if acc_dist >= lookahead:
-                return float(q[0]), float(q[1]), i + 1
+            for t in t_candidates:
+                if 0.0 <= t <= 1.0:
+                    candidate = p + t * d
+                    best_target = candidate
+                    best_index = i + (1 if t >= 0.999 else 0)
+                    break
 
-        gx, gy = path[-1]
-        return float(gx), float(gy), len(path) - 1
+            if best_target is not None:
+                break
+
+        if best_target is None:
+            best_target = np.array(path[-1], dtype=float)
+            best_index = len(path) - 1
+
+        return float(best_target[0]), float(best_target[1]), best_index
 
     def follow_path(self):
         if self.in_relocalization:
@@ -523,11 +634,14 @@ class Operate:
             if self.autonomous_mode and not self.in_relocalization:
                 self.notification = "Reached target!"
                 self.autonomous_mode = False
+            self.require_heading_alignment = False
             return
 
         robot_x = float(self.ekf.robot.state[0, 0])
         robot_y = float(self.ekf.robot.state[1, 0])
         robot_theta = float(self.ekf.robot.state[2, 0])
+        goal_x, goal_y = self.path[-1]
+        dist_to_goal = np.hypot(goal_x - robot_x, goal_y - robot_y)
 
         tx, ty = self.path[self.current_path_index]
         if np.hypot(tx - robot_x, ty - robot_y) < self.wp_reached_radius:
@@ -536,7 +650,63 @@ class Operate:
                 self.command['wheel_speed'] = [0, 0]
                 self.notification = "Reached target!"
                 self.autonomous_mode = False
+                self.require_heading_alignment = False
                 return
+
+        if (
+            self.current_path_index >= len(self.path) - 1
+            and len(self.path) >= 2
+        ):
+            prev_wp = self.path[-2]
+            seg = np.array([goal_x - prev_wp[0], goal_y - prev_wp[1]])
+            to_robot = np.array([robot_x - prev_wp[0], robot_y - prev_wp[1]])
+            seg_len_sq = float(np.dot(seg, seg))
+            if seg_len_sq > 1e-8 and float(np.dot(to_robot, seg)) > seg_len_sq:
+                self.command['wheel_speed'] = [0, 0]
+                self.current_path_index = len(self.path)
+                self.notification = "Reached target!"
+                self.autonomous_mode = False
+                self.require_heading_alignment = False
+                return
+
+        # Keep the active waypoint aligned with the closest point on the path ahead
+        nearest_idx = self.current_path_index
+        nearest_dist = float('inf')
+        search_start = max(self.current_path_index - 1, 0)
+        for idx in range(search_start, len(self.path)):
+            px, py = self.path[idx]
+            dist = np.hypot(px - robot_x, py - robot_y)
+            if dist < nearest_dist:
+                nearest_dist = dist
+                nearest_idx = idx
+            # stop searching once we are comfortably ahead along the route
+            if dist <= self.lookahead:
+                break
+
+        if nearest_idx > self.current_path_index:
+            self.current_path_index = nearest_idx
+
+        if self.require_heading_alignment and len(self.path) > 1:
+            align_idx = min(self.current_path_index + 1, len(self.path) - 1)
+            align_x, align_y = self.path[align_idx]
+            dx_align = align_x - robot_x
+            dy_align = align_y - robot_y
+            if np.hypot(dx_align, dy_align) > 1e-3:
+                desired_theta = np.arctan2(dy_align, dx_align)
+                angle_error = (desired_theta - robot_theta + np.pi) % (2 * np.pi) - np.pi
+                if abs(angle_error) > self.heading_align_tolerance:
+                    turn_speed = np.clip(
+                        angle_error * self.heading_align_gain,
+                        -self.heading_align_max_speed,
+                        self.heading_align_max_speed,
+                    )
+                    if abs(turn_speed) < self.heading_align_min_speed:
+                        sign = 1.0 if (turn_speed if turn_speed != 0 else angle_error) >= 0 else -1.0
+                        turn_speed = self.heading_align_min_speed * sign
+                    self.command['wheel_speed'] = [-turn_speed, turn_speed]
+                    self.notification = "Aligning heading to path"
+                    return
+            self.require_heading_alignment = False
 
         if not self.use_pure_pursuit:
             target_x, target_y = self.path[self.current_path_index]
@@ -552,10 +722,14 @@ class Operate:
             right = np.clip(linear_speed + angular_speed * baseline / 2.0, -0.6, 0.6)
             self.command['wheel_speed'] = [left, right]
         else:
+            effective_lookahead = self.lookahead
+            if dist_to_goal < self.lookahead:
+                effective_lookahead = max(0.05, dist_to_goal + 0.5 * self.wp_reached_radius)
+
             lx, ly, idx = self._find_lookahead_target(
                 (robot_x, robot_y, robot_theta),
                 self.path,
-                self.lookahead
+                effective_lookahead
             )
             if idx > self.current_path_index:
                 self.current_path_index = idx
@@ -566,10 +740,15 @@ class Operate:
             x_r = np.cos(robot_theta) * dx + np.sin(robot_theta) * dy
             y_r = -np.sin(robot_theta) * dx + np.cos(robot_theta) * dy
 
-            Ld = max(0.05, self.lookahead)
+            Ld = max(0.05, effective_lookahead)
             kappa = (2.0 * y_r) / (Ld * Ld)
 
-            v = self.pp_max_linear
+            curvature = abs(kappa)
+            v = min(self.pp_max_linear, max(0.0, dist_to_goal * self.pp_speed_gain))
+            if curvature > 1e-6:
+                v = min(v, self.pp_max_linear / (1.0 + 2.5 * curvature))
+            if self.current_path_index < len(self.path) - 1 and v < 0.08:
+                v = min(self.pp_max_linear, 0.08)
             omega = np.clip(v * kappa, -self.pp_max_angular, self.pp_max_angular)
 
             baseline = float(self.ekf.robot.baseline)


### PR DESCRIPTION
## Summary
- align the occupancy grid conversions with cell centers and refresh the planner grid when rebuilding the map
- densify and smooth planned paths before following them so the robot tracks the drawn route more faithfully
- tune the pure pursuit lookahead and add curvature-aware speed limiting to reduce corner cutting near obstacles

## Testing
- python -m compileall operate.py

------
https://chatgpt.com/codex/tasks/task_e_68d7964b32e08328bc7704c824e47242