### PR TITLE
Enable autonomous navigation and mapping

### DIFF
--- a/operate.py
+++ b/operate.py
@@ -1,5 +1,8 @@
-import cv2 
+import cv2
 import time
+import math
+import json
+import csv
 import shutil
 import argparse
 import os, sys
@@ -17,6 +20,10 @@ from slam.aruco_sensor import ArucoSensor
 # import CV components (M3)
 sys.path.insert(0,"{}/cv/".format(os.getcwd()))
 from cv.detector import ObjectDetector
+
+# object pose estimation helpers
+import object_pose_est as obj_pose
+from object_pose_est import get_image_info, estimate_pose
 
 
 class Operate:
@@ -49,7 +56,30 @@ class Operate:
         else:
             self.obj_detector = ObjectDetector(args.ckpt, use_gpu=False)
             self.cv_vis = np.ones((480,640,3))* 100
-        
+
+        # Load object metadata for pose estimation (fruit mapping)
+        self.object_list = []
+        self.object_dimensions = []
+        try:
+            with open('object_list.csv', 'r') as file:
+                reader = csv.DictReader(file)
+                rows = list(reader)
+                self.object_list = [row['object'] for row in rows]
+                self.object_dimensions = [
+                    [float(row['length(m)']), float(row['width(m)']), float(row['height(m)'])]
+                    for row in rows
+                ]
+            obj_pose.object_list = self.object_list
+            obj_pose.object_dimensions = self.object_dimensions
+        except FileNotFoundError:
+            self.notification = 'object_list.csv missing - fruit mapping disabled'
+            self.object_list = []
+            self.object_dimensions = []
+        except KeyError:
+            self.notification = 'object_list.csv malformed - fruit mapping disabled'
+            self.object_list = []
+            self.object_dimensions = []
+
         # Create a folder to save raw camera images after pressing "i" (M3)
         self.raw_img_dir = 'raw_images/'
         if not os.path.exists(self.raw_img_dir):
@@ -74,11 +104,49 @@ class Operate:
         self.control_clock = time.time()
         self.img = np.zeros([480,640,3], dtype=np.uint8)
         self.aruco_img = np.zeros([480,640,3], dtype=np.uint8)
-        self.obj_detector_pred = np.zeros([480,640], dtype=np.uint8)        
+        self.obj_detector_pred = np.zeros([480,640], dtype=np.uint8)
         self.bg = pygame.image.load('ui/gui_mask.jpg')
+        self.map_font = pygame.font.Font('ui/8-BitMadness.ttf', 18)
+        self.slam_view_rect = None
+
+        # Autonomous navigation state
+        self.autonomous_mode = False
+        self.target_point = None
+        self.navigation_tolerance = 0.08
+        self.heading_tolerance = 0.2
+        self.forward_speed = 0.25
+        self.turn_speed = 0.18
+        self.correction_gain = 0.6
+        self.auto_detection_period = 1.0
+        self.last_auto_detection = 0.0
+
+        # Localization and mapping caches
+        self.true_marker_map, self.true_object_map = self.load_true_map('truemap.txt')
+        self.object_pose_estimates = {}
+        self.object_pose_counts = {}
+        self.localization_complete = False
+        self.fruit_colours = {
+            'redapple': (220, 20, 60),
+            'greenapple': (0, 155, 0),
+            'orange': (255, 140, 0),
+            'capsicum': (178, 34, 34),
+            'yellowlemon': (250, 250, 50),
+            'greenlemon': (34, 139, 34),
+            'mango': (255, 215, 0)
+        }
+
+        # Load known marker map into EKF for localization reference
+        if self.true_marker_map:
+            try:
+                self.ekf.load_map('truemap.txt')
+            except FileNotFoundError:
+                pass
+
+        # Perform initial localization routine with slow rotational scan
+        self.perform_initial_localization()
 
     # wheel control
-    def control(self):       
+    def control(self):
         left_speed, right_speed = self.botconnect.set_velocity(self.command['wheel_speed'])
         dt = time.time() - self.control_clock
         drive_measurement = DriveMeasurement(left_speed, right_speed, dt)
@@ -100,7 +168,225 @@ class Operate:
         fileB = os.path.join(calib_dir, 'baseline.txt')
         baseline = np.loadtxt(fileB, delimiter=',')
         robot = Robot(baseline, scale, camera_matrix, dist_coeffs)
+        self.camera_matrix = camera_matrix
         return EKF(robot)
+
+    def load_true_map(self, fname):
+        marker_map = {}
+        object_map = {}
+        if not os.path.exists(fname):
+            return marker_map, object_map
+        try:
+            with open(fname, 'r') as f:
+                data = json.load(f)
+        except json.JSONDecodeError:
+            return marker_map, object_map
+
+        for key, value in data.items():
+            if key.startswith('aruco'):
+                try:
+                    tag_id = int(key.split('_')[0].replace('aruco', ''))
+                except ValueError:
+                    continue
+                marker_map[tag_id] = np.array([[float(value['x'])], [float(value['y'])]])
+            else:
+                name = key.replace('_0', '')
+                object_map[name] = {'x': float(value['x']), 'y': float(value['y'])}
+        return marker_map, object_map
+
+    def perform_initial_localization(self):
+        if self.localization_complete or not self.true_marker_map:
+            return
+
+        self.notification = 'Initial localization: scanning for markers'
+        pygame.event.pump()
+
+        detections = {}
+        scan_steps = 12
+        rotate_duration = 0.45
+        pause_duration = 0.35
+
+        for step in range(scan_steps):
+            self.command['wheel_speed'] = [-self.turn_speed * 0.8, self.turn_speed * 0.8]
+            end_time = time.time() + rotate_duration
+            while time.time() < end_time:
+                self.control()
+                time.sleep(0.05)
+            self.command['wheel_speed'] = [0, 0]
+            self.control()
+            time.sleep(pause_duration)
+
+            self.take_pic()
+            sensor_measurement, self.aruco_img = self.aruco_sensor.detect_marker_positions(self.img)
+            for measurement in sensor_measurement:
+                tag = int(measurement.tag)
+                if tag not in self.true_marker_map:
+                    continue
+                detections.setdefault(tag, []).append(measurement.position)
+
+            if self.obj_detector is not None:
+                self.detect_object(force=True, autop=True)
+
+            pygame.event.pump()
+
+        success = self.estimate_robot_pose_from_markers(detections)
+        if success:
+            self.localization_complete = True
+            self.ekf_on = True
+            self.notification = 'Localization complete'
+        else:
+            self.notification = 'Localization failed: insufficient markers'
+
+        self.command['wheel_speed'] = [0, 0]
+        self.control()
+
+    def estimate_robot_pose_from_markers(self, detections):
+        if len(detections) < 2:
+            return False
+
+        local_points = []
+        world_points = []
+        for tag, samples in detections.items():
+            if tag not in self.true_marker_map or not samples:
+                continue
+            average_local = np.mean(np.hstack(samples), axis=1, keepdims=True)
+            local_points.append(average_local)
+            world_points.append(self.true_marker_map[tag])
+
+        if len(local_points) < 2:
+            return False
+
+        local_arr = np.hstack(local_points)
+        world_arr = np.hstack(world_points)
+
+        try:
+            R, t = self.ekf.umeyama(local_arr, world_arr)
+        except Exception:
+            return False
+
+        theta = math.atan2(R[1, 0], R[0, 0])
+        self.ekf.robot.state[0, 0] = t[0]
+        self.ekf.robot.state[1, 0] = t[1]
+        self.ekf.robot.state[2, 0] = (theta + np.pi) % (2 * np.pi) - np.pi
+
+        return True
+
+    def maybe_run_auto_detector(self):
+        if self.obj_detector is None:
+            return
+        now = time.time()
+        if self.autonomous_mode and (now - self.last_auto_detection >= self.auto_detection_period):
+            self.detect_object(force=True, autop=True)
+            self.last_auto_detection = now
+
+    def update_object_map(self, detections):
+        if not detections or not self.object_list or self.camera_matrix is None:
+            return
+
+        robot_pose = self.ekf.robot.state.flatten()
+        detection_payload = {'detections': detections}
+        completed = get_image_info(detection_payload, robot_pose)
+        if not completed:
+            return
+
+        estimates = estimate_pose(self.camera_matrix, completed)
+        if not estimates:
+            return
+
+        for name, pose in estimates.items():
+            key = name.lower()
+            prev = self.object_pose_estimates.get(key)
+            if prev:
+                count = self.object_pose_counts.get(key, 1)
+                new_count = count + 1
+                avg_x = (prev['x'] * count + pose['x']) / new_count
+                avg_y = (prev['y'] * count + pose['y']) / new_count
+                self.object_pose_estimates[key] = {'x': avg_x, 'y': avg_y}
+                self.object_pose_counts[key] = new_count
+            else:
+                self.object_pose_estimates[key] = {'x': pose['x'], 'y': pose['y']}
+                self.object_pose_counts[key] = 1
+
+    def set_autonomous_target(self, world_point):
+        if not self.localization_complete:
+            self.notification = 'Localization incomplete - cannot navigate yet'
+            return
+        self.target_point = world_point
+        self.autonomous_mode = True
+        self.last_auto_detection = 0.0
+        self.notification = f'Navigating to ({world_point[0]:.2f}, {world_point[1]:.2f})'
+
+    @staticmethod
+    def _wrap_to_pi(angle):
+        return (angle + np.pi) % (2 * np.pi) - np.pi
+
+    def update_autonomous_navigation(self):
+        if not self.autonomous_mode or self.target_point is None:
+            return
+
+        robot_x = self.ekf.robot.state[0, 0]
+        robot_y = self.ekf.robot.state[1, 0]
+        robot_theta = self.ekf.robot.state[2, 0]
+
+        dx = self.target_point[0] - robot_x
+        dy = self.target_point[1] - robot_y
+        distance = math.hypot(dx, dy)
+
+        if distance < self.navigation_tolerance:
+            self.command['wheel_speed'] = [0, 0]
+            self.autonomous_mode = False
+            self.target_point = None
+            self.notification = 'Arrived at destination'
+            return
+
+        desired_heading = math.atan2(dy, dx)
+        heading_error = self._wrap_to_pi(desired_heading - robot_theta)
+
+        if abs(heading_error) > self.heading_tolerance:
+            turn = self.turn_speed if heading_error > 0 else -self.turn_speed
+            self.command['wheel_speed'] = [-turn, turn]
+        else:
+            correction = self.correction_gain * heading_error
+            left = np.clip(self.forward_speed - correction, -0.4, 0.4)
+            right = np.clip(self.forward_speed + correction, -0.4, 0.4)
+            self.command['wheel_speed'] = [left, right]
+
+    def world_to_surface(self, world_xy, surface):
+        if surface is None:
+            return None
+        size = surface.get_size()
+        return self.relative_to_surface((world_xy[0] - self.ekf.robot.state[0, 0],
+                                         world_xy[1] - self.ekf.robot.state[1, 0]), size)
+
+    def relative_to_surface(self, rel_xy, size):
+        if size is None:
+            return None
+        w, h = size
+        m2pixel = 100.0
+        raw_x = -rel_xy[0] * m2pixel + w / 2.0
+        raw_y = rel_xy[1] * m2pixel + h / 2.0
+        screen_x = int((h - 1) - raw_y)
+        screen_y = int((w - 1) - raw_x)
+        return (screen_x, screen_y)
+
+    def screen_to_world(self, pos):
+        if self.slam_view_rect is None:
+            return None
+        local_x = pos[0] - self.slam_view_rect.left
+        local_y = pos[1] - self.slam_view_rect.top
+        if local_x < 0 or local_y < 0 or local_x >= self.slam_view_rect.width or local_y >= self.slam_view_rect.height:
+            return None
+
+        w = self.slam_view_rect.width
+        h = self.slam_view_rect.height
+        raw_x = (w - 1) - local_y
+        raw_y = (h - 1) - local_x
+        m2pixel = 100.0
+        rel_x = -(raw_x - w / 2.0) / m2pixel
+        rel_y = (raw_y - h / 2.0) / m2pixel
+        world_x = rel_x + self.ekf.robot.state[0, 0]
+        world_y = rel_y + self.ekf.robot.state[1, 0]
+        return (world_x, world_y)
 
     # SLAM with ARUCO markers       
     def perform_slam(self, drive_measurement):
@@ -151,34 +437,47 @@ class Operate:
             self.notification = f'{f_} is saved'
 
     # using computer vision to detect objects
-    def detect_object(self):
-        if self.command['run_obj_detector'] and self.obj_detector is not None:
-            # self.img is RGB -> model (OpenCV/YOLO) expects BGR
-            img_bgr = cv2.cvtColor(self.img, cv2.COLOR_RGB2BGR)
+    def detect_object(self, force=False, autop=False):
+        if self.obj_detector is None:
+            return
 
-            # UPDATED: detector returns (mask, annotated_vis_bgr, detections)
-            pred_mask, vis_bgr, detections = self.obj_detector.detect_single_image(img_bgr)
+        run_detector = self.command['run_obj_detector'] or force
+        if not run_detector:
+            return
 
-            # Bring visualization back to RGB for Pygame display
-            self.obj_detector_pred = pred_mask
-            self.cv_vis = cv2.cvtColor(vis_bgr, cv2.COLOR_BGR2RGB)
+        # self.img is RGB -> model (OpenCV/YOLO) expects BGR
+        img_bgr = cv2.cvtColor(self.img, cv2.COLOR_RGB2BGR)
 
-            # Stash everything needed for saving to pred.txt later
-            H, W = img_bgr.shape[:2]
-            self.obj_detector_output = (
-                self.obj_detector_pred,           # image to save (mask/vis)
-                self.ekf.robot.state.tolist(),    # robot pose (JSON-friendly)
-                detections,                       # list of {name, bbox_xyxy, conf}
-                W,                                # im_w
-                H                                 # im_h
-            )
+        # UPDATED: detector returns (mask, annotated_vis_bgr, detections)
+        pred_mask, vis_bgr, detections = self.obj_detector.detect_single_image(img_bgr)
 
-            # Nice notification
-            n_types = len({d['name'] for d in detections}) if detections else 0
+        # Bring visualization back to RGB for Pygame display
+        self.obj_detector_pred = pred_mask
+        self.cv_vis = cv2.cvtColor(vis_bgr, cv2.COLOR_BGR2RGB)
+
+        # Stash everything needed for saving to pred.txt later
+        H, W = img_bgr.shape[:2]
+        self.obj_detector_output = (
+            self.obj_detector_pred,           # image to save (mask/vis)
+            self.ekf.robot.state.tolist(),    # robot pose (JSON-friendly)
+            detections,                       # list of {name, bbox_xyxy, conf}
+            W,                                # im_w
+            H                                 # im_h
+        )
+
+        # Nice notification
+        n_types = len({d['name'] for d in detections}) if detections else 0
+        if autop:
+            self.notification = f'Auto-detected {n_types} object type(s)'
+        else:
             self.notification = f'{n_types} object type(s) detected'
 
-            # Reset the command latch
-            self.command['run_obj_detector'] = False
+        # Reset the command latch
+        self.command['run_obj_detector'] = False
+        self.last_auto_detection = time.time()
+
+        # Update mapped fruit positions
+        self.update_object_map(detections)
 
 
     # paint the GUI            
@@ -191,7 +490,10 @@ class Operate:
 
         # paint SLAM outputs
         ekf_view = self.ekf.draw_slam_state(res=(520, 480+v_pad), not_pause = self.ekf_on)
-        canvas.blit(ekf_view, (2*h_pad+320, v_pad))
+        self.annotate_slam_overlay(ekf_view)
+        slam_pos = (2*h_pad+320, v_pad)
+        self.slam_view_rect = pygame.Rect(slam_pos, ekf_view.get_size())
+        canvas.blit(ekf_view, slam_pos)
         robot_view = cv2.resize(self.aruco_img, (320, 240))
         self.draw_pygame_window(canvas, robot_view, position=(h_pad, v_pad))
 
@@ -216,6 +518,28 @@ class Operate:
         canvas.blit(count_down_surface, (2*h_pad+320+5, 530))
         return canvas
 
+    def annotate_slam_overlay(self, surface):
+        if surface is None:
+            return
+
+        # Draw detected fruits
+        for name, pose in self.object_pose_estimates.items():
+            pt = self.world_to_surface((pose['x'], pose['y']), surface)
+            if pt is None:
+                continue
+            colour = self.fruit_colours.get(name, (80, 80, 80))
+            pygame.draw.circle(surface, colour, pt, 6)
+            label = self.map_font.render(name[:1].upper(), False, colour)
+            surface.blit(label, (pt[0] - label.get_width() // 2, pt[1] - label.get_height() // 2))
+
+        # Draw current navigation target
+        if self.target_point is not None:
+            pt = self.world_to_surface(self.target_point, surface)
+            if pt is not None:
+                pygame.draw.circle(surface, (40, 40, 220), pt, 9, 2)
+                pygame.draw.line(surface, (40, 40, 220), (pt[0] - 6, pt[1]), (pt[0] + 6, pt[1]), 2)
+                pygame.draw.line(surface, (40, 40, 220), (pt[0], pt[1] - 6), (pt[0], pt[1] + 6), 2)
+
     @staticmethod
     def draw_pygame_window(canvas, cv2_img, position):
         cv2_img = np.rot90(cv2_img)
@@ -237,18 +561,26 @@ class Operate:
         for event in pygame.event.get():
             # drive forward
             if event.type == pygame.KEYDOWN and event.key == pygame.K_UP:
+                self.autonomous_mode = False
+                self.target_point = None
                 self.command['wheel_speed'] = [0.3, 0.3]
                  # TODO
             # drive backward
             elif event.type == pygame.KEYDOWN and event.key == pygame.K_DOWN:
+                self.autonomous_mode = False
+                self.target_point = None
                 self.command['wheel_speed'] = [-0.3,-0.3]
                  # TODO
             # turn left
             elif event.type == pygame.KEYDOWN and event.key == pygame.K_LEFT:
+                self.autonomous_mode = False
+                self.target_point = None
                 self.command['wheel_speed'] = [-0.3,0.3]
                  # TODO
             # drive right
             elif event.type == pygame.KEYDOWN and event.key == pygame.K_RIGHT:
+                self.autonomous_mode = False
+                self.target_point = None
                 self.command['wheel_speed'] = [0.3,-0.3]
                  # TODO
             # stop
@@ -313,6 +645,14 @@ class Operate:
                 self.quit = True
             elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
                 self.quit = True
+            elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+                target = self.screen_to_world(event.pos)
+                if target is not None:
+                    self.set_autonomous_target(target)
+            elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 3:
+                self.autonomous_mode = False
+                self.target_point = None
+                self.notification = 'Autonomous navigation cancelled'
         if self.quit:
             pygame.quit()
             sys.exit()
@@ -358,9 +698,11 @@ if __name__ == "__main__":
     operate = Operate(args)
     while start:
         operate.update_keyboard()
+        operate.update_autonomous_navigation()
         operate.take_pic()
         drive_measurement = operate.control()
         operate.perform_slam(drive_measurement)
+        operate.maybe_run_auto_detector()
         operate.save_result()
         operate.detect_object()
         operate.draw(canvas)


### PR DESCRIPTION
## Summary
- perform a marker-based localization scan on startup using the true map and estimated robot pose
- enable click-to-navigate autonomous driving with basic heading and distance control plus cancellation controls
- run periodic fruit detection during autonomous operation and map detections onto the SLAM view with annotations

## Testing
- python -m compileall operate.py

------
https://chatgpt.com/codex/tasks/task_e_68d8fb771c988328b450628539240ab7